### PR TITLE
Specify project language as C in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-PROJECT(http-parser)
+PROJECT(http-parser C)
 
 set(targetName httpparser)
 


### PR DESCRIPTION
cmake try to validate C++ compiler. It causes an error on cross compilation environment.
Since we has migrated C++ to C, we don't need the check any more.

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com