### PR TITLE
Reduce binary size by removing not used function and strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,14 @@ else()
 endif()
 
 message("HTTP Parser configured with:")
-message(STATUS "CMAKE_BUILD_TYPE     ${CMAKE_BUILD_TYPE}")
-message(STATUS "OS                   ${OS}")
-message(STATUS "NUTTX_HOME           ${NUTTX_HOME}")
+message(STATUS "CMAKE_BUILD_TYPE          ${CMAKE_BUILD_TYPE}")
+message(STATUS "OS                        ${OS}")
+message(STATUS "NUTTX_HOME                ${NUTTX_HOME}")
+message(STATUS "ENABLE_MEMORY_CONSTRAINTS ${ENABLE_MEMORY_CONSTRAINTS}")
+
+if(ENABLE_MEMORY_CONSTRAINTS)
+  set(DEFINES_HTTPPARSER ${DEFINES_HTTPPARSER} HTTPPARSER_ENABLE_MEMORY_CONSTRAINTS)
+endif()
 
 ADD_LIBRARY(${targetName} STATIC http_parser.c)
+target_compile_definitions(${targetName} PRIVATE ${DEFINES_HTTPPARSER})

--- a/http_parser.c
+++ b/http_parser.c
@@ -453,7 +453,11 @@ do {                                                                 \
 
 
 /* Map errno values to strings for human-readable output */
+#ifdef HTTPPARSER_ENABLE_MEMORY_CONSTRAINTS
+#define HTTP_STRERROR_GEN(n, s) { "HPE_" #n, "" },
+#else
 #define HTTP_STRERROR_GEN(n, s) { "HPE_" #n, s },
+#endif
 static struct {
   const char *name;
   const char *description;
@@ -2157,6 +2161,7 @@ http_errno_name(enum http_errno err) {
   return http_strerror_tab[err].name;
 }
 
+#ifndef HTTPPARSER_ENABLE_MEMORY_CONSTRAINTS
 const char *
 http_errno_description(enum http_errno err) {
   assert(((size_t) err) <
@@ -2406,6 +2411,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 
   return 0;
 }
+#endif
 
 void
 http_parser_pause(http_parser *parser, int paused) {
@@ -2421,6 +2427,7 @@ http_parser_pause(http_parser *parser, int paused) {
   }
 }
 
+#ifndef HTTPPARSER_ENABLE_MEMORY_CONSTRAINTS
 int
 http_body_is_final(const struct http_parser *parser) {
     return parser->state == s_message_done;
@@ -2432,3 +2439,4 @@ http_parser_version(void) {
          HTTP_PARSER_VERSION_MINOR * 0x00100 |
          HTTP_PARSER_VERSION_PATCH * 0x00001;
 }
+#endif

--- a/http_parser.h
+++ b/http_parser.h
@@ -280,6 +280,7 @@ struct http_parser_url {
 };
 
 
+#ifndef HTTPPARSER_ENABLE_MEMORY_CONSTRAINTS
 /* Returns the library version. Bits 16-23 contain the major version number,
  * bits 8-15 the minor version number and bits 0-7 the patch level.
  * Usage example:
@@ -291,6 +292,7 @@ struct http_parser_url {
  *   printf("http_parser v%u.%u.%u\n", major, minor, patch);
  */
 unsigned long http_parser_version(void);
+#endif
 
 void http_parser_init(http_parser *parser, enum http_parser_type type);
 
@@ -322,6 +324,7 @@ const char *http_method_str(enum http_method m);
 /* Return a string name of the given error */
 const char *http_errno_name(enum http_errno err);
 
+#ifndef HTTPPARSER_ENABLE_MEMORY_CONSTRAINTS
 /* Return a string description of the given error */
 const char *http_errno_description(enum http_errno err);
 
@@ -329,12 +332,15 @@ const char *http_errno_description(enum http_errno err);
 int http_parser_parse_url(const char *buf, size_t buflen,
                           int is_connect,
                           struct http_parser_url *u);
+#endif
 
 /* Pause or un-pause the parser; a nonzero value pauses */
 void http_parser_pause(http_parser *parser, int paused);
 
+#ifndef HTTPPARSER_ENABLE_MEMORY_CONSTRAINTS
 /* Checks if this is the final chunk of the body. */
 int http_body_is_final(const http_parser *parser);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Remove the definition of currenlty not used in iotjs
 : http_errno_description, http_parser_parse_url, ...
- Remove error description strings

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com